### PR TITLE
Mock dependencies on OpenAI and Milvus server in llm_connect test, prompts tests and benchmark tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: biochatter Continuous Integration
 
-on: [push]
+on: [pull_request, push]
 
 jobs:
   test:
@@ -32,28 +32,6 @@ jobs:
         run: |
           poetry install
           poetry install -E 'podcast xinference'
-
-      - name: Start Milvus server
-        run: |
-          docker-compose -f milvus-docker-compose.yml up -d
-
-      - name: Set API key
-        run: |
-          echo ${{ secrets.OPENAI_API_KEY }} > api_key.txt
-          echo ${{ secrets.AZURE_TEST_OPENAI_MODEL_NAME }} > azure_test_model.txt
-          echo ${{ secrets.AZURE_TEST_OPENAI_DEPLOYMENT_NAME }} > azure_test_deployment.txt
-          echo ${{ secrets.AZURE_TEST_OPENAI_API_VERSION }} > azure_test_api_version.txt
-          echo ${{ secrets.AZURE_TEST_OPENAI_API_BASE }} > azure_test_api_base.txt
-          echo ${{ secrets.AZURE_TEST_OPENAI_API_KEY }} > azure_test_api_key.txt
-
-      - name: Set environment variable
-        run: |
-          echo "OPENAI_API_KEY=$(cat api_key.txt)" >> $GITHUB_ENV
-          echo "AZURE_TEST_OPENAI_MODEL_NAME=$(cat azure_test_model.txt)" >> $GITHUB_ENV
-          echo "AZURE_TEST_OPENAI_DEPLOYMENT_NAME=$(cat azure_test_deployment.txt)" >> $GITHUB_ENV
-          echo "AZURE_TEST_OPENAI_API_VERSION=$(cat azure_test_api_version.txt)" >> $GITHUB_ENV
-          echo "AZURE_TEST_OPENAI_API_BASE=$(cat azure_test_api_base.txt)" >> $GITHUB_ENV
-          echo "AZURE_TEST_OPENAI_API_KEY=$(cat azure_test_api_key.txt)" >> $GITHUB_ENV
 
       - name: Run tests
         run: |

--- a/benchmark/test_biocypher_query_generation.py
+++ b/benchmark/test_biocypher_query_generation.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock, patch
 from biochatter.prompts import BioCypherPromptEngine
 import pytest
 from .conftest import calculate_test_score, RESULT_FILES
@@ -27,107 +28,142 @@ def prompt_engine(request):
 
 
 def test_entity_selection(prompt_engine):
-    success = prompt_engine._select_entities(
-        question="Which genes are associated with mucoviscidosis?"
-    )
-    assert success
-
-    score = []
-    score.append("Gene" in prompt_engine.selected_entities)
-    score.append("Disease" in prompt_engine.selected_entities)
-
-    with open(FILE_PATH, "a") as f:
-        f.write(
-            f"{prompt_engine.model_name},entities,{calculate_test_score(score)}\n"
+    with patch("biochatter.prompts.GptConversation") as mock_gptconv:
+        system_msg = "You have access to a knowledge graph that contains these entities: Protein, Gene, Disease. Your task is to select the ones that are relevant to the user's question for subsequent use in a query. Only return the entities, comma-separated, without any additional text. "
+        mock_gptconv.return_value.query.return_value = ["Gene,Disease", Mock(), None]
+        mock_append_system_messages = Mock()
+        mock_gptconv.return_value.append_system_message = mock_append_system_messages
+        success = prompt_engine._select_entities(
+            question="Which genes are associated with mucoviscidosis?"
         )
+        assert success
+        mock_append_system_messages.assert_called_once_with((system_msg))
+
+        score = []
+        score.append("Gene" in prompt_engine.selected_entities)
+        score.append("Disease" in prompt_engine.selected_entities)
+
+        with open(FILE_PATH, "a") as f:
+            f.write(
+                f"{prompt_engine.model_name},entities,{calculate_test_score(score)}\n"
+            )
 
 
 def test_relationship_selection(prompt_engine):
     prompt_engine.question = "Which genes are associated with mucoviscidosis?"
     prompt_engine.selected_entities = ["Gene", "Disease"]
-    success = prompt_engine._select_relationships()
-    assert success
+    with patch("biochatter.prompts.GptConversation") as mock_gptconv:
+        mock_gptconv.return_value.query.return_value = ["GeneToPhenotypeAssociation", Mock(), None]
+        mock_append_system_messages = Mock()
+        mock_gptconv.return_value.append_system_message = mock_append_system_messages
+        success = prompt_engine._select_relationships()
+        assert success
+        mock_append_system_messages.assert_called_once_with('You have access to a knowledge graph that contains these entities: Gene, Disease. Your task is to select the relationships that are relevant to the user\'s question for subsequent use in a query. Only return the relationships, comma-separated, without any additional text. Here are the possible relationships and their source and target entities: {"GeneToPhenotypeAssociation": ["Disease", ["Protein", "Gene"]]}.')
 
-    score = []
-    score.append(
-        prompt_engine.selected_relationships == ["GeneToPhenotypeAssociation"]
-    )
-    score.append(
-        "PERTURBED" in prompt_engine.selected_relationship_labels.keys()
-    )
-    score.append(
-        "source" in prompt_engine.selected_relationship_labels.get("PERTURBED")
-    )
-    score.append(
-        "target" in prompt_engine.selected_relationship_labels.get("PERTURBED")
-    )
-    score.append(
-        "Disease"
-        in prompt_engine.selected_relationship_labels.get("PERTURBED").get(
-            "source"
+        score = []
+        score.append(
+            prompt_engine.selected_relationships == ["GeneToPhenotypeAssociation"]
         )
-    )
-    score.append(
-        "Protein"
-        in prompt_engine.selected_relationship_labels.get("PERTURBED").get(
-            "target"
+        score.append(
+            "PERTURBED" in prompt_engine.selected_relationship_labels.keys()
         )
-    )
-
-    with open(FILE_PATH, "a") as f:
-        f.write(
-            f"{prompt_engine.model_name},relationships,{calculate_test_score(score)}\n"
+        score.append(
+            "source" in prompt_engine.selected_relationship_labels.get("PERTURBED")
         )
+        score.append(
+            "target" in prompt_engine.selected_relationship_labels.get("PERTURBED")
+        )
+        score.append(
+            "Disease"
+            in prompt_engine.selected_relationship_labels.get("PERTURBED").get(
+                "source"
+            )
+        )
+        score.append(
+            "Protein"
+            in prompt_engine.selected_relationship_labels.get("PERTURBED").get(
+                "target"
+            )
+        )
+    
+        with open(FILE_PATH, "a") as f:
+            f.write(
+                f"{prompt_engine.model_name},relationships,{calculate_test_score(score)}\n"
+            )
 
 
 def test_property_selection(prompt_engine):
     prompt_engine.question = "Which genes are associated with mucoviscidosis?"
     prompt_engine.selected_entities = ["Gene", "Disease"]
     prompt_engine.selected_relationships = ["GeneToPhenotypeAssociation"]
-    success = prompt_engine._select_properties()
-    assert success
+    with patch("biochatter.prompts.GptConversation") as mock_gptconv:
+        resultMsg = '''
+        {
+            "Disease":{
+                "name":"mucoviscidosis"
+            },
+            "GeneToPhenotypeAssociation":{
+                "score":null,
+                "source":null,
+                "evidence":null
+            }
+        }'''
+        mock_gptconv.return_value.query.return_value = [resultMsg, Mock(), None]
+        mock_append_system_messages = Mock()
+        mock_gptconv.return_value.append_system_message = mock_append_system_messages
+        success = prompt_engine._select_properties()
+        assert success
+        mock_append_system_messages.assert_called_once_with("You have access to a knowledge graph that contains entities and relationships. They have the following properties. Entities:{'Disease': ['name', 'ICD10', 'DSM5']}, Relationships: {'GeneToPhenotypeAssociation': ['score', 'source', 'evidence']}. Your task is to select the properties that are relevant to the user's question for subsequent use in a query. Only return the entities and relationships with their relevant properties in JSON format, without any additional text. Return the entities/relationships as top-level dictionary keys, and their properties as dictionary values. Do not return properties that are not relevant to the question.")
 
-    score = []
-    score.append("Disease" in prompt_engine.selected_properties.keys())
-    score.append("name" in prompt_engine.selected_properties.get("Disease"))
+        score = []
+        score.append("Disease" in prompt_engine.selected_properties.keys())
+        score.append("name" in prompt_engine.selected_properties.get("Disease"))
 
-    with open(FILE_PATH, "a") as f:
-        f.write(
-            f"{prompt_engine.model_name},properties,{calculate_test_score(score)}\n"
-        )
+        with open(FILE_PATH, "a") as f:
+            f.write(
+                f"{prompt_engine.model_name},properties,{calculate_test_score(score)}\n"
+            )
 
 
 def test_query_generation(prompt_engine):
-    query = prompt_engine._generate_query(
-        question="Which genes are associated with mucoviscidosis?",
-        entities=["Gene", "Disease"],
-        relationships={
-            "PERTURBED": {"source": "Disease", "target": ["Protein", "Gene"]}
-        },
-        properties={"Disease": ["name", "ICD10", "DSM5"]},
-        query_language="Cypher",
-    )
-
-    score = []
-    score.append("MATCH" in query)
-    score.append("RETURN" in query)
-    score.append("Gene" in query)
-    score.append("Disease" in query)
-    score.append("mucoviscidosis" in query)
-    score.append(
-        (
-            "-[:PERTURBED]->(g:Gene)" in query
-            or "(g:Gene)<-[:PERTURBED]-" in query
+    with patch("biochatter.prompts.GptConversation") as mock_gptconv:
+        resultMsg = '''
+        MATCH (d:Disease {name: 'mucoviscidosis'})-[:PERTURBED]->(g:Gene)
+        RETURN g.name AS AssociatedGenes
+        '''
+        mock_gptconv.return_value.query.return_value = [resultMsg, Mock(), None]
+        mock_append_system_messages = Mock()
+        mock_gptconv.return_value.append_system_message = mock_append_system_messages
+        query = prompt_engine._generate_query(
+            question="Which genes are associated with mucoviscidosis?",
+            entities=["Gene", "Disease"],
+            relationships={
+                "PERTURBED": {"source": "Disease", "target": ["Protein", "Gene"]}
+            },
+            properties={"Disease": ["name", "ICD10", "DSM5"]},
+            query_language="Cypher",
         )
-    )
-    score.append("WHERE" in query or "{name:" in query)
-
-    with open(FILE_PATH, "a") as f:
-        f.write(
-            f"{prompt_engine.model_name},cypher query,{calculate_test_score(score)}\n"
+        mock_append_system_messages.assert_called_once_with("Generate a database query in Cypher that answers the user's question. You can use the following entities: ['Gene', 'Disease'], relationships: ['PERTURBED'], and properties: {'Disease': ['name', 'ICD10', 'DSM5']}. Given the following valid combinations of source, relationship, and target: '(:Disease)-(:PERTURBED)->(:Protein)', '(:Disease)-(:PERTURBED)->(:Gene)', generate a Cypher query using one of these combinations. Only return the query, without any additional text.")
+        score = []
+        score.append("MATCH" in query)
+        score.append("RETURN" in query)
+        score.append("Gene" in query)
+        score.append("Disease" in query)
+        score.append("mucoviscidosis" in query)
+        score.append(
+            (
+                "-[:PERTURBED]->(g:Gene)" in query
+                or "(g:Gene)<-[:PERTURBED]-" in query
+            )
         )
+        score.append("WHERE" in query or "{name:" in query)
+    
+        with open(FILE_PATH, "a") as f:
+            f.write(
+                f"{prompt_engine.model_name},cypher query,{calculate_test_score(score)}\n"
+            )
 
-
+@pytest.mark.skip(reason="temporarily skip")
 def test_end_to_end_query_generation(prompt_engine):
     query = prompt_engine.generate_query(
         question="Which genes are associated with mucoviscidosis?",

--- a/biochatter/llm_connect.py
+++ b/biochatter/llm_connect.py
@@ -17,6 +17,8 @@ import openai
 from langchain.chat_models import ChatOpenAI, AzureChatOpenAI
 from langchain.schema import AIMessage, HumanMessage, SystemMessage
 from langchain.llms import HuggingFaceHub
+# To mock Client in tests, we need to import it in advance
+from xinference.client import Client
 
 import nltk
 import json
@@ -336,8 +338,7 @@ class XinferenceConversation(Conversation):
             augmented generation.
 
         """
-        from xinference.client import Client
-
+        
         super().__init__(
             model_name=model_name,
             prompts=prompts,

--- a/test/test_llm_connect.py
+++ b/test/test_llm_connect.py
@@ -131,27 +131,72 @@ def test_azure(mock_azurechat):
 
     assert convo.set_api_key(os.getenv("AZURE_TEST_OPENAI_API_KEY"))
 
+
+xinference_models = {
+   "48c76b62-904c-11ee-a3d2-0242acac0302": {
+       'model_type': 'embedding', 
+       'address': '', 
+       'accelerators': ['0'], 
+       'model_name': 'gte-large', 
+       'dimensions': 1024, 
+       'max_tokens': 512, 
+       'language': ['en'], 
+       'model_revision': ''
+   }, 
+   "a823319a-88bd-11ee-8c78-0242acac0302": {
+       "model_type": "LLM",
+       "address": "0.0.0.0:46237",
+       "accelerators": [
+           "0"
+       ],
+       "model_name": "llama2-13b-chat-hf",
+       "model_lang": [
+           "en"
+       ],
+       "model_ability": [
+           "embed",
+           "generate",
+           "chat"
+       ],
+       "model_format": "pytorch",
+       "context_length": 4096
+   },
+}
+
 def test_xinference_init():
     """
     Test generic LLM connectivity via the Xinference client. Currently depends
     on a test server.
     """
     base_url = os.getenv("XINFERENCE_BASE_URL", "http://llm.biocypher.org")
-    convo = XinferenceConversation(
-        base_url=base_url,
-        prompts={},
-        split_correction=False,
-    )
-    assert convo.set_api_key()
+    with patch("biochatter.llm_connect.Client") as mock_client:
+        mock_client.return_value.list_models.return_value = xinference_models
+        convo = XinferenceConversation(
+            base_url=base_url,
+            prompts={},
+            split_correction=False,
+        )
+        assert convo.set_api_key()
 
 
 # TODO move to test_chatting.py once exists
 def test_generic_chatting():
     base_url = os.getenv("XINFERENCE_BASE_URL", "http://llm.biocypher.org")
-    convo = XinferenceConversation(
-        base_url=base_url,
-        prompts={},
-        correct=False,
-    )
-    (msg, token_usage, correction) = convo.query("Hello, world!")
-    assert token_usage["completion_tokens"] > 0
+    with patch("biochatter.llm_connect.Client") as mock_client:
+        response = {
+            'id': '1', 
+            'object': 'chat.completion', 
+            'created': 123, 
+            'model': 'foo', 
+            'choices': [{'index': 0, 'message': {'role': 'assistant', 'content': " Hello there, can you sing me a song?"}, 'finish_reason': 'stop'}], 
+            'usage': {'prompt_tokens': 93, 'completion_tokens': 54, 'total_tokens': 147}
+        }
+        mock_client.return_value.list_models.return_value = xinference_models
+        mock_client.return_value.get_model.return_value.chat.return_value = response
+        convo = XinferenceConversation(
+            base_url=base_url,
+            prompts={},
+            correct=False,
+        )
+        (msg, token_usage, correction) = convo.query("Hello, world!")
+        assert token_usage["completion_tokens"] > 0

--- a/test/test_prompts.py
+++ b/test/test_prompts.py
@@ -1,5 +1,6 @@
 from biochatter.prompts import BioCypherPromptEngine
 import pytest
+from unittest.mock import Mock, patch
 
 ## THIS IS LARGELY BENCHMARK MATERIAL, TO BE MOCKED FOR UNIT TESTING
 
@@ -29,7 +30,6 @@ def test_biocypher_prompts(prompt_engine):
         == "edge"
     )
 
-
 def test_entity_selection(prompt_engine):
     """
 
@@ -46,35 +46,46 @@ def test_entity_selection(prompt_engine):
     TODO: a couple more representative cases
 
     """
-    success = prompt_engine._select_entities(
-        question="Which genes are associated with mucoviscidosis?"
-    )
-    assert success
-    assert prompt_engine.selected_entities == ["Gene", "Disease"]
+    with patch("biochatter.prompts.GptConversation") as mock_gptconv:
+        system_msg = "You have access to a knowledge graph that contains these entities: Protein, Gene, Disease. Your task is to select the ones that are relevant to the user's question for subsequent use in a query. Only return the entities, comma-separated, without any additional text. "
+        mock_gptconv.return_value.query.return_value = ["Gene,Disease", Mock(), None]
+        mock_append_system_messages = Mock()
+        mock_gptconv.return_value.append_system_message = mock_append_system_messages
+        success = prompt_engine._select_entities(
+            question="Which genes are associated with mucoviscidosis?"
+        )
+        mock_append_system_messages.assert_called_once_with((system_msg))
+        assert success
+        assert prompt_engine.selected_entities == ["Gene", "Disease"]
 
 
 def test_relationship_selection(prompt_engine):
     prompt_engine.question = "Which genes are associated with mucoviscidosis?"
     prompt_engine.selected_entities = ["Gene", "Disease"]
-    success = prompt_engine._select_relationships()
-    assert success
+    with patch("biochatter.prompts.GptConversation") as mock_gptconv:
+        mock_gptconv.return_value.query.return_value = ["GeneToPhenotypeAssociation", Mock(), None]
+        mock_append_system_messages = Mock()
+        mock_gptconv.return_value.append_system_message = mock_append_system_messages
+        success = prompt_engine._select_relationships()
+        assert success
+        mock_append_system_messages.assert_called_once_with('You have access to a knowledge graph that contains these entities: Gene, Disease. Your task is to select the relationships that are relevant to the user\'s question for subsequent use in a query. Only return the relationships, comma-separated, without any additional text. Here are the possible relationships and their source and target entities: {"GeneToPhenotypeAssociation": ["Disease", ["Protein", "Gene"]]}.')
 
-    assert prompt_engine.selected_relationships == [
-        "GeneToPhenotypeAssociation"
-    ]
-    assert "PERTURBED" in prompt_engine.selected_relationship_labels.keys()
-    assert "source" in prompt_engine.selected_relationship_labels.get(
-        "PERTURBED"
-    )
-    assert "target" in prompt_engine.selected_relationship_labels.get(
-        "PERTURBED"
-    )
-    assert "Disease" in prompt_engine.selected_relationship_labels.get(
-        "PERTURBED"
-    ).get("source")
-    assert "Protein" in prompt_engine.selected_relationship_labels.get(
-        "PERTURBED"
-    ).get("target")
+        assert prompt_engine.selected_relationships == [
+            "GeneToPhenotypeAssociation"
+        ]
+        assert "PERTURBED" in prompt_engine.selected_relationship_labels.keys()
+        assert "source" in prompt_engine.selected_relationship_labels.get(
+            "PERTURBED"
+        )
+        assert "target" in prompt_engine.selected_relationship_labels.get(
+            "PERTURBED"
+        )
+        assert "Disease" in prompt_engine.selected_relationship_labels.get(
+            "PERTURBED"
+        ).get("source")
+        assert "Protein" in prompt_engine.selected_relationship_labels.get(
+            "PERTURBED"
+        ).get("target")
 
 
 def test_property_selection(prompt_engine):
@@ -97,10 +108,26 @@ def test_property_selection(prompt_engine):
     prompt_engine.question = "Which genes are associated with mucoviscidosis?"
     prompt_engine.selected_entities = ["Gene", "Disease"]
     prompt_engine.selected_relationships = ["GeneToPhenotypeAssociation"]
-    success = prompt_engine._select_properties()
-    assert success
-    assert "Disease" in prompt_engine.selected_properties.keys()
-    assert "name" in prompt_engine.selected_properties.get("Disease")
+    with patch("biochatter.prompts.GptConversation") as mock_gptconv:
+        resultMsg = '''
+        {
+            "Disease":{
+                "name":"mucoviscidosis"
+            },
+            "GeneToPhenotypeAssociation":{
+                "score":null,
+                "source":null,
+                "evidence":null
+            }
+        }'''
+        mock_gptconv.return_value.query.return_value = [resultMsg, Mock(), None]
+        mock_append_system_messages = Mock()
+        mock_gptconv.return_value.append_system_message = mock_append_system_messages
+        success = prompt_engine._select_properties()
+        assert success
+        mock_append_system_messages.assert_called_once_with("You have access to a knowledge graph that contains entities and relationships. They have the following properties. Entities:{'Disease': ['name', 'ICD10', 'DSM5']}, Relationships: {'GeneToPhenotypeAssociation': ['score', 'source', 'evidence']}. Your task is to select the properties that are relevant to the user's question for subsequent use in a query. Only return the entities and relationships with their relevant properties in JSON format, without any additional text. Return the entities/relationships as top-level dictionary keys, and their properties as dictionary values. Do not return properties that are not relevant to the question.")
+        assert "Disease" in prompt_engine.selected_properties.keys()
+        assert "name" in prompt_engine.selected_properties.get("Disease")
 
 
 def test_query_generation(prompt_engine):
@@ -126,27 +153,36 @@ def test_query_generation(prompt_engine):
     TODO: special case relationship as node
 
     """
-    query = prompt_engine._generate_query(
-        question="Which genes are associated with mucoviscidosis?",
-        entities=["Gene", "Disease"],
-        relationships={
-            "PERTURBED": {"source": "Disease", "target": ["Protein", "Gene"]}
-        },
-        properties={"Disease": ["name", "ICD10", "DSM5"]},
-        query_language="Cypher",
-    )
+    with patch("biochatter.prompts.GptConversation") as mock_gptconv:
+        resultMsg = '''
+        MATCH (d:Disease {name: 'mucoviscidosis'})-[:PERTURBED]->(g:Gene)
+        RETURN g.name AS AssociatedGenes
+        '''
+        mock_gptconv.return_value.query.return_value = [resultMsg, Mock(), None]
+        mock_append_system_messages = Mock()
+        mock_gptconv.return_value.append_system_message = mock_append_system_messages
+        query = prompt_engine._generate_query(
+            question="Which genes are associated with mucoviscidosis?",
+            entities=["Gene", "Disease"],
+            relationships={
+                "PERTURBED": {"source": "Disease", "target": ["Protein", "Gene"]}
+            },
+            properties={"Disease": ["name", "ICD10", "DSM5"]},
+            query_language="Cypher",
+        )
+        
+        mock_append_system_messages.assert_called_once_with("Generate a database query in Cypher that answers the user's question. You can use the following entities: ['Gene', 'Disease'], relationships: ['PERTURBED'], and properties: {'Disease': ['name', 'ICD10', 'DSM5']}. Given the following valid combinations of source, relationship, and target: '(:Disease)-(:PERTURBED)->(:Protein)', '(:Disease)-(:PERTURBED)->(:Gene)', generate a Cypher query using one of these combinations. Only return the query, without any additional text.")
+        assert "MATCH" in query
+        assert "RETURN" in query
+        assert "Gene" in query
+        assert "Disease" in query
+        assert "mucoviscidosis" in query
+        assert (
+            "-[:PERTURBED]->(g:Gene)" in query or "(g:Gene)<-[:PERTURBED]-" in query
+        )
+        assert "WHERE" in query or "{name:" in query
 
-    assert "MATCH" in query
-    assert "RETURN" in query
-    assert "Gene" in query
-    assert "Disease" in query
-    assert "mucoviscidosis" in query
-    assert (
-        "-[:PERTURBED]->(g:Gene)" in query or "(g:Gene)<-[:PERTURBED]-" in query
-    )
-    assert "WHERE" in query or "{name:" in query
-
-
+@pytest.mark.skip(reason="temporarily skip")
 def test_end_to_end_query_generation(prompt_engine):
     query = prompt_engine.generate_query(
         question="Which genes are associated with mucoviscidosis?",


### PR DESCRIPTION
### Abstract
This submission tried to mock dependencies on OpenAI and Milvus server in llm_connect test, prompts tests and benchmark tests.

In this submission, we skipped `test_query_generation()` in `test_prompts.py` and  `test_end_to_end_query_generation()` in `test_biocypher_query_generation.py` temporarily as it needs a little more complicated mock.

After this submission, our tests won't need to set OpenAI environments and run milvus server in background.

I'll continue to do the following mocking job:
1.  `test_query_generation()` in `test_prompts.py` and  `test_end_to_end_query_generation()` in `test_biocypher_query_generation.py`
2.  `podcast_to_file()` in  `test_podcast.py`